### PR TITLE
SC-9054: Update Copyright year to 2026 in Sandbox and Tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ packages
 *.db
 Build/
 Examples/lastbuild.txt
+# Claude Code
+.claude/

--- a/Sandbox/CustomerExamples/3DChartChangePropertiesDynamically/3DChartChangePropertiesDynamically.csproj
+++ b/Sandbox/CustomerExamples/3DChartChangePropertiesDynamically/3DChartChangePropertiesDynamically.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/3DChartScatterSeriesOnWalls/Scatter3DOnChartWalls.csproj
+++ b/Sandbox/CustomerExamples/3DChartScatterSeriesOnWalls/Scatter3DOnChartWalls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/3DChartSelectPointsOnSurfaceMesh/SurfaceMesh3DWithSelectablePoints.csproj
+++ b/Sandbox/CustomerExamples/3DChartSelectPointsOnSurfaceMesh/SurfaceMesh3DWithSelectablePoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/3DScatterChart_DragPointModifier/Scatter3DChart_DragPointModifier.csproj
+++ b/Sandbox/CustomerExamples/3DScatterChart_DragPointModifier/Scatter3DChart_DragPointModifier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AddObjectsToA3DChart/AddObjectsToA3DChart/AddObjectsToA3DChart.csproj
+++ b/Sandbox/CustomerExamples/AddObjectsToA3DChart/AddObjectsToA3DChart/AddObjectsToA3DChart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<OutputType>WinExe</OutputType>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>

--- a/Sandbox/CustomerExamples/AnimatedDataSeries/AnimatedDataSeriesFilter.csproj
+++ b/Sandbox/CustomerExamples/AnimatedDataSeries/AnimatedDataSeriesFilter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AnnotationDragModifier3D/AnnotationDragModifier3D.csproj
+++ b/Sandbox/CustomerExamples/AnnotationDragModifier3D/AnnotationDragModifier3D.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AnnotationsBindingToTextBox/AnnotationsBindingToTextBox.csproj
+++ b/Sandbox/CustomerExamples/AnnotationsBindingToTextBox/AnnotationsBindingToTextBox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AspectRatioGridLines/AspectRatioGridLines.csproj
+++ b/Sandbox/CustomerExamples/AspectRatioGridLines/AspectRatioGridLines.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AspectRatioSandbox/AspectRatios.csproj
+++ b/Sandbox/CustomerExamples/AspectRatioSandbox/AspectRatios.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/AxisMvvmApplyStyle/AxisMvvmApplyStyle/AxisMvvmApplyStyle.csproj
+++ b/Sandbox/CustomerExamples/AxisMvvmApplyStyle/AxisMvvmApplyStyle/AxisMvvmApplyStyle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ChartPrinting/ChartPrintingMultiPaneCharts.csproj
+++ b/Sandbox/CustomerExamples/ChartPrinting/ChartPrintingMultiPaneCharts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ChartsWidthSync/ChartWidthSynchronization.csproj
+++ b/Sandbox/CustomerExamples/ChartsWidthSync/ChartWidthSynchronization.csproj
@@ -5,7 +5,7 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup>
-    <Copyright>Copyright © 2011-2023</Copyright>
+    <Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/Sandbox/CustomerExamples/ColumnSeriesNoGaps/ColumnSeriesNoGaps.csproj
+++ b/Sandbox/CustomerExamples/ColumnSeriesNoGaps/ColumnSeriesNoGaps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CompositeAnnotationsMvvm/CompositeAnnotationsMvvm.csproj
+++ b/Sandbox/CustomerExamples/CompositeAnnotationsMvvm/CompositeAnnotationsMvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomAxisBandsProvider/CustomAxisBandsProvider.csproj
+++ b/Sandbox/CustomerExamples/CustomAxisBandsProvider/CustomAxisBandsProvider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomCompositeAnnotationExample/CustomCompositeAnnotationExample.csproj
+++ b/Sandbox/CustomerExamples/CustomCompositeAnnotationExample/CustomCompositeAnnotationExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomModifiersSandbox/CustomModifierSandbox.csproj
+++ b/Sandbox/CustomerExamples/CustomModifiersSandbox/CustomModifierSandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomPointMarker/CustomPointMarker.csproj
+++ b/Sandbox/CustomerExamples/CustomPointMarker/CustomPointMarker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomSeriesMvvm/CustomSeriesMvvm.csproj
+++ b/Sandbox/CustomerExamples/CustomSeriesMvvm/CustomSeriesMvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
+++ b/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/DPI_Aware_SciChartSurface/DpiAware_SciChartSurface.csproj
+++ b/Sandbox/CustomerExamples/DPI_Aware_SciChartSurface/DpiAware_SciChartSurface.csproj
@@ -6,7 +6,7 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <Copyright>Copyright © 2011-2023</Copyright>
+    <Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Sandbox/CustomerExamples/DashedLinesChart/DashedLinesChart.csproj
+++ b/Sandbox/CustomerExamples/DashedLinesChart/DashedLinesChart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/DigitalAnalyzerPerformanceDemo/SciChart_DigitalAnalyzerPerformanceDemo.csproj
+++ b/Sandbox/CustomerExamples/DigitalAnalyzerPerformanceDemo/SciChart_DigitalAnalyzerPerformanceDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/DoubleAxisAsDateTimeAxis/DoubleAxisAsDateTimeAxis.csproj
+++ b/Sandbox/CustomerExamples/DoubleAxisAsDateTimeAxis/DoubleAxisAsDateTimeAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/DoubleScaleDiscontinuousDateTimeAxis/DoubleScaleDiscontinuousDateTimeAxis.csproj
+++ b/Sandbox/CustomerExamples/DoubleScaleDiscontinuousDateTimeAxis/DoubleScaleDiscontinuousDateTimeAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/DynamicVerticallyStackedAxis/DynamicVerticallyStackedAxis.csproj
+++ b/Sandbox/CustomerExamples/DynamicVerticallyStackedAxis/DynamicVerticallyStackedAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/EliminatingFlickerInDirectXRenderer/EliminatingFlicker.csproj
+++ b/Sandbox/CustomerExamples/EliminatingFlickerInDirectXRenderer/EliminatingFlicker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/EventOnZoomExtentsCompleted/EventOnZoomExtentsCompleted.csproj
+++ b/Sandbox/CustomerExamples/EventOnZoomExtentsCompleted/EventOnZoomExtentsCompleted.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/HitTestSandbox/HitTestSandbox.csproj
+++ b/Sandbox/CustomerExamples/HitTestSandbox/HitTestSandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ImplicitStyles/ImplicitStyles.csproj
+++ b/Sandbox/CustomerExamples/ImplicitStyles/ImplicitStyles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/KeyboardMoveXozModifier3D/KeyboardMoveXozModifier3D.csproj
+++ b/Sandbox/CustomerExamples/KeyboardMoveXozModifier3D/KeyboardMoveXozModifier3D.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/LabStyleCharts/LabStyleCharts.csproj
+++ b/Sandbox/CustomerExamples/LabStyleCharts/LabStyleCharts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/LabelIndividualStylingColoring/LabelIndividualStylingColoring.csproj
+++ b/Sandbox/CustomerExamples/LabelIndividualStylingColoring/LabelIndividualStylingColoring.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/LegendAxisVisibilityCheckbox/LegendAxisVisibilityCheckbox.csproj
+++ b/Sandbox/CustomerExamples/LegendAxisVisibilityCheckbox/LegendAxisVisibilityCheckbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/Lidar3DPointCloudDemo/Lidar3DPointCloudDemo.csproj
+++ b/Sandbox/CustomerExamples/Lidar3DPointCloudDemo/Lidar3DPointCloudDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MarketProfileTradingExample/MarketProfileTradingChart.csproj
+++ b/Sandbox/CustomerExamples/MarketProfileTradingExample/MarketProfileTradingChart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MirroredYAxis/MvvmVersion/mirrored YAxis/mirrored YAxis.csproj
+++ b/Sandbox/CustomerExamples/MirroredYAxis/MvvmVersion/mirrored YAxis/mirrored YAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MirroredYAxis/XamlVersion/mirrored YAxis/mirrored YAxis.csproj
+++ b/Sandbox/CustomerExamples/MirroredYAxis/XamlVersion/mirrored YAxis/mirrored YAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MouseEventsOnAnnotations/MouseEventsOnAnnotations.csproj
+++ b/Sandbox/CustomerExamples/MouseEventsOnAnnotations/MouseEventsOnAnnotations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MultiLineDateTimeAxisLabels/MultiLineDateTimeAxisLabels.csproj
+++ b/Sandbox/CustomerExamples/MultiLineDateTimeAxisLabels/MultiLineDateTimeAxisLabels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/MutipleAppDomainsExample/MutipleAppDomainsExample.csproj
+++ b/Sandbox/CustomerExamples/MutipleAppDomainsExample/MutipleAppDomainsExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>Exe</OutputType>

--- a/Sandbox/CustomerExamples/MutipleUIThreadExample/MutipleUIThreadExample.csproj
+++ b/Sandbox/CustomerExamples/MutipleUIThreadExample/MutipleUIThreadExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/OffScreenExportExample/OffScreenExportExample.csproj
+++ b/Sandbox/CustomerExamples/OffScreenExportExample/OffScreenExportExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
     <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
     <UseWPF>True</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Sandbox/CustomerExamples/OilAndGasExample/OilAndGasExample.csproj
+++ b/Sandbox/CustomerExamples/OilAndGasExample/OilAndGasExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/Plane3DAnnotation/Plane3DAnnotation.csproj
+++ b/Sandbox/CustomerExamples/Plane3DAnnotation/Plane3DAnnotation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ResamplingOfGridDataSeries3D/ResamplingOfGridDataSeries3D.csproj
+++ b/Sandbox/CustomerExamples/ResamplingOfGridDataSeries3D/ResamplingOfGridDataSeries3D.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/RotatedAxisLabels/RotatedAxisLabels.csproj
+++ b/Sandbox/CustomerExamples/RotatedAxisLabels/RotatedAxisLabels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/SciChartSurfaceMeshSelection/SciChartSurfaceMeshSelection.csproj
+++ b/Sandbox/CustomerExamples/SciChartSurfaceMeshSelection/SciChartSurfaceMeshSelection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/SciChart_SyncMultiChartMvvm/SciChart_SyncMultiChartMvvm.csproj
+++ b/Sandbox/CustomerExamples/SciChart_SyncMultiChartMvvm/SciChart_SyncMultiChartMvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2025</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ScrollbarAboveAxis/ScrollbarAboveAxis.csproj
+++ b/Sandbox/CustomerExamples/ScrollbarAboveAxis/ScrollbarAboveAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ScrollbarMvvmAxis/ScrollbarMvvmAxis.csproj
+++ b/Sandbox/CustomerExamples/ScrollbarMvvmAxis/ScrollbarMvvmAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/SelectSeriesOnHover/SelectSeriesOnHover/SelectSeriesOnHover.csproj
+++ b/Sandbox/CustomerExamples/SelectSeriesOnHover/SelectSeriesOnHover/SelectSeriesOnHover.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/SlimLineRenderableSeries/SlimLineRenderableSeriesExample.csproj
+++ b/Sandbox/CustomerExamples/SlimLineRenderableSeries/SlimLineRenderableSeriesExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/State Series Example/Method1 Chartception/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method1 Chartception/State Series Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/State Series Example/Method2 Axis Panel Template/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method2 Axis Panel Template/State Series Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/State Series Example/Method3 Custom Series/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method3 Custom Series/State Series Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/StockChartLogAxis/StockChartLogAxis.csproj
+++ b/Sandbox/CustomerExamples/StockChartLogAxis/StockChartLogAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/StringsOnXAxis/StringsOnXAxis.csproj
+++ b/Sandbox/CustomerExamples/StringsOnXAxis/StringsOnXAxis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/StripChart/ScrollingStripChart.csproj
+++ b/Sandbox/CustomerExamples/StripChart/ScrollingStripChart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers.csproj
+++ b/Sandbox/CustomerExamples/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/SweepingEcgSeries/SweepingEcg.csproj
+++ b/Sandbox/CustomerExamples/SweepingEcgSeries/SweepingEcg.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/TextAnnotationDynamicSize/TextAnnotationDynamicSize.csproj
+++ b/Sandbox/CustomerExamples/TextAnnotationDynamicSize/TextAnnotationDynamicSize.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ThresholdedLineSeries/DragThresholdMvvm.csproj
+++ b/Sandbox/CustomerExamples/ThresholdedLineSeries/DragThresholdMvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/TicklinesUniformGrid/TicklinesUniformGrid.csproj
+++ b/Sandbox/CustomerExamples/TicklinesUniformGrid/TicklinesUniformGrid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/TimelineControl/TimeLineControl.csproj
+++ b/Sandbox/CustomerExamples/TimelineControl/TimeLineControl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/TouchScreenModifiers/TouchInputSandbox.csproj
+++ b/Sandbox/CustomerExamples/TouchScreenModifiers/TouchInputSandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/TruePolar/TruePolarChart.csproj
+++ b/Sandbox/CustomerExamples/TruePolar/TruePolarChart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/UsingRenderContextAPI/UsingRenderContextApi.csproj
+++ b/Sandbox/CustomerExamples/UsingRenderContextAPI/UsingRenderContextApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate.csproj
+++ b/Sandbox/CustomerExamples/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/VerticalSliceModifierMvvm/VerticalSliceModifierMvvm.csproj
+++ b/Sandbox/CustomerExamples/VerticalSliceModifierMvvm/VerticalSliceModifierMvvm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/VisualXcceleratorEnableTest/VisualXcceleratorEnableTest.csproj
+++ b/Sandbox/CustomerExamples/VisualXcceleratorEnableTest/VisualXcceleratorEnableTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/YAxisSameZeroLine/YAxisSameZeroLine.csproj
+++ b/Sandbox/CustomerExamples/YAxisSameZeroLine/YAxisSameZeroLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ZoomExtentsAfterMvvmSeriesChanges/ZoomExtentsAfterMvvmSeriesChanged.csproj
+++ b/Sandbox/CustomerExamples/ZoomExtentsAfterMvvmSeriesChanges/ZoomExtentsAfterMvvmSeriesChanged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/CustomerExamples/ZoomExtentsOnVisibilityChanged/ZoomExtentsOnVisibilityChanged.csproj
+++ b/Sandbox/CustomerExamples/ZoomExtentsOnVisibilityChanged/ZoomExtentsOnVisibilityChanged.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/DirectXDeploymentTestApp/NuGet PackageReference version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
+++ b/Sandbox/DirectXDeploymentTestApp/NuGet PackageReference version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/DirectXDeploymentTestApp/NuGet Packages.config version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
+++ b/Sandbox/DirectXDeploymentTestApp/NuGet Packages.config version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo.csproj
+++ b/Sandbox/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/LicensingTestApp/WinForms/WindowsFormsApplication1/WindowsFormsApplication1/WindowsFormsApplication1.csproj
+++ b/Sandbox/LicensingTestApp/WinForms/WindowsFormsApplication1/WindowsFormsApplication1/WindowsFormsApplication1.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<UseWindowsForms>True</UseWindowsForms>

--- a/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App net6.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App net6.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/LicensingTestApp/Wpf - AsyncLicenseLoading/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - AsyncLicenseLoading/WpfApplication1/Licensing Test App.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/LicensingTestApp/Wpf/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf/WpfApplication1/Licensing Test App.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart/ChartProviderSciChart_v1.7.2.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart/ChartProviderSciChart_v1.7.2.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<OutputPath>bin\$(Configuration)</OutputPath>

--- a/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart_Trunk/ChartProviderSciChart_Trunk.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart_Trunk/ChartProviderSciChart_Trunk.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>Library</OutputType>

--- a/Sandbox/WPFChartPerformanceBenchmark/ChartProviders.Common/ChartProviders.Common.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/ChartProviders.Common/ChartProviders.Common.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<OutputPath>bin\$(Configuration)</OutputPath>

--- a/Sandbox/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Sandbox/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark_SC_DirectX_vs_Software/WPFChartPerformanceBenchmark - DirectX vs Software.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/WPFChartPerformanceBenchmark_SC_DirectX_vs_Software/WPFChartPerformanceBenchmark - DirectX vs Software.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright � SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 02 Creating a SciChartSurface/Tutorial 02 Creating a SciChartSurface.csproj
+++ b/Tutorials/Code-Behind/Tutorial 02 Creating a SciChartSurface/Tutorial 02 Creating a SciChartSurface.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 03 Adding Series to a Chart/Tutorial 03 Adding Series to a Chart.csproj
+++ b/Tutorials/Code-Behind/Tutorial 03 Adding Series to a Chart/Tutorial 03 Adding Series to a Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 04 Adding Zooming, Panning/Tutorial 04 Adding Zooming, Panning.csproj
+++ b/Tutorials/Code-Behind/Tutorial 04 Adding Zooming, Panning/Tutorial 04 Adding Zooming, Panning.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 05 Adding Tooltips, Legends/Tutorial 05 Adding Tooltips, Legends.csproj
+++ b/Tutorials/Code-Behind/Tutorial 05 Adding Tooltips, Legends/Tutorial 05 Adding Tooltips, Legends.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 06 Realtime Updates/Tutorial 06 Realtime Updates.csproj
+++ b/Tutorials/Code-Behind/Tutorial 06 Realtime Updates/Tutorial 06 Realtime Updates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 07 Adding Annotations/Tutorial 07 Adding Annotations.csproj
+++ b/Tutorials/Code-Behind/Tutorial 07 Adding Annotations/Tutorial 07 Adding Annotations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 08 Multiple Axis/Tutorial 08 Multiple Axis.csproj
+++ b/Tutorials/Code-Behind/Tutorial 08 Multiple Axis/Tutorial 08 Multiple Axis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/Code-Behind/Tutorial 09 Linking Multiple Charts/Tutorial 09 Linking Multiple Charts.csproj
+++ b/Tutorials/Code-Behind/Tutorial 09 Linking Multiple Charts/Tutorial 09 Linking Multiple Charts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 02b Creating a SciChartSurface with MVVM/Tutorial 02b Creating a SciChartSurface with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 02b Creating a SciChartSurface with MVVM/Tutorial 02b Creating a SciChartSurface with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 03b Adding Series to a Chart with MVVM/Tutorial 03b Adding Series to a Chart with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 03b Adding Series to a Chart with MVVM/Tutorial 03b Adding Series to a Chart with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 04b Adding Zooming Panning with MVVM/Tutorial 04b Adding Zooming Panning with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 04b Adding Zooming Panning with MVVM/Tutorial 04b Adding Zooming Panning with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 06b Adding Realtime Updates with MVVM/Tutorial 06b Adding Realtime Updates with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 06b Adding Realtime Updates with MVVM/Tutorial 06b Adding Realtime Updates with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 07b Adding Annotations with MVVM/Tutorial 07b Adding Annotations with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 07b Adding Annotations with MVVM/Tutorial 07b Adding Annotations with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 08b Adding Multiple Axis with MVVM/Tutorial 08b Adding Multiple Axis with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 08b Adding Multiple Axis with MVVM/Tutorial 08b Adding Multiple Axis with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/MVVM/Tutorial 09b Linking Multiple Charts with MVVM/Tutorial 09b Linking Multiple Charts with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 09b Linking Multiple Charts with MVVM/Tutorial 09b Linking Multiple Charts with MVVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/SciChart 3D/Tutorial 02-3D Creating a SciChart3DSurface/Tutorial 02 Creating a SciChart3DSurface.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 02-3D Creating a SciChart3DSurface/Tutorial 02 Creating a SciChart3DSurface.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/SciChart 3D/Tutorial 03-3D Adding Series to a 3D Chart/Tutorial 03 Adding Series to a 3D Chart.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 03-3D Adding Series to a 3D Chart/Tutorial 03 Adding Series to a 3D Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>

--- a/Tutorials/SciChart 3D/Tutorial 04-3D Adding Zooming, Panning Behavior/Tutorial 04 Adding Zooming Panning Behavior.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 04-3D Adding Zooming, Panning Behavior/Tutorial 04 Adding Zooming Panning Behavior.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2023</Copyright>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>


### PR DESCRIPTION
## Summary
- Updated `<Copyright>` field to `Copyright © SciChart Ltd 2011-2026` in all `.csproj` files under `Sandbox/` and `Tutorials/`
- Fixed 2 files in `CustomerExamples` that were missing "SciChart Ltd" in the copyright string
- Added `.claude/` to `.gitignore`

Resolves: [SC-9054](https://abtsoftware.myjetbrains.com/youtrack/issue/SC-9054/Update-years-in-the-Copyright-field-for-all-Sandbox-examples)