### PR TITLE
SC-9370: Add Tutorial 10b - Synchronizing Axis Ranges with MVVM

### DIFF
--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/App.xaml
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/App.xaml
@@ -1,0 +1,8 @@
+<Application x:Class="SciChart.Mvvm.Tutorial.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+
+    <Application.Resources/>
+
+</Application>

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/App.xaml.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace SciChart.Mvvm.Tutorial
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/CelsiusFahrenheitTransform.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/CelsiusFahrenheitTransform.cs
@@ -1,0 +1,45 @@
+using SciChart.Charting.Model.ChartSeries;
+using SciChart.Data.Model;
+
+namespace SciChart.Mvvm.Tutorial
+{
+    /// <summary>
+    /// Converts between Fahrenheit (this axis's range) and Celsius (the canonical group range).
+    /// Attach this transform to the Fahrenheit axis. The Celsius axis needs no transform
+    /// because its range IS the group range (identity).
+    /// </summary>
+    public class CelsiusFahrenheitTransform : IRangeSyncTransform
+    {
+        /// <summary>
+        /// Converts the axis range (Fahrenheit) to the canonical group range (Celsius).
+        /// Called when THIS axis changes and the new range must be broadcast to the group.
+        /// </summary>
+        public IRange ToGroupRange(IRange axisRange)
+        {
+            if (axisRange is DoubleRange r)
+            {
+                return new DoubleRange(
+                    (r.Min - 32) * 5.0 / 9.0,
+                    (r.Max - 32) * 5.0 / 9.0);
+            }
+
+            return axisRange;
+        }
+
+        /// <summary>
+        /// Converts the canonical group range (Celsius) to the axis range (Fahrenheit).
+        /// Called when ANOTHER axis in the group changes and this axis must update.
+        /// </summary>
+        public IRange FromGroupRange(IRange groupRange)
+        {
+            if (groupRange is DoubleRange r)
+            {
+                return new DoubleRange(
+                    r.Min * 9.0 / 5.0 + 32,
+                    r.Max * 9.0 / 5.0 + 32);
+            }
+
+            return groupRange;
+        }
+    }
+}

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/ChartViewModel.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/ChartViewModel.cs
@@ -20,7 +20,7 @@ namespace SciChart.Mvvm.Tutorial
             set
             {
                 _chartTitle = value;
-                OnPropertyChanged("ChartTitle");
+                OnPropertyChanged(nameof(ChartTitle));
             }
         }
 

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/ChartViewModel.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/ChartViewModel.cs
@@ -1,0 +1,54 @@
+using System.Collections.ObjectModel;
+using SciChart.Charting.Model.ChartSeries;
+using SciChart.Charting.Visuals.Axes;
+using SciChart.Data.Model;
+
+namespace SciChart.Mvvm.Tutorial
+{
+    public class ChartViewModel : BindableObject
+    {
+        private string _chartTitle;
+        private bool _rangeSyncOnZoomExtents;
+
+        public ObservableCollection<IAxisViewModel> XAxes { get; } = new ObservableCollection<IAxisViewModel>();
+        public ObservableCollection<IAxisViewModel> YAxes { get; } = new ObservableCollection<IAxisViewModel>();
+        public ObservableCollection<IRenderableSeriesViewModel> RenderableSeries { get; } = new ObservableCollection<IRenderableSeriesViewModel>();
+
+        public string ChartTitle
+        {
+            get => _chartTitle;
+            set
+            {
+                _chartTitle = value;
+                OnPropertyChanged("ChartTitle");
+            }
+        }
+
+        /// <summary>
+        /// Toggles RangeSyncOnZoomExtents on every axis in this chart.
+        /// When true, ZoomExtents propagates this chart's computed extents
+        /// to all other axes in the same sync group. When false, ZoomExtents
+        /// fits to local data only and sync is temporarily bypassed.
+        /// </summary>
+        public bool RangeSyncOnZoomExtents
+        {
+            get => _rangeSyncOnZoomExtents;
+            set
+            {
+                if (_rangeSyncOnZoomExtents != value)
+                {
+                    _rangeSyncOnZoomExtents = value;
+                    OnPropertyChanged(nameof(RangeSyncOnZoomExtents));
+
+                    foreach (var axis in XAxes)
+                        if (axis is AxisBaseViewModel vm)
+                            vm.RangeSyncSourceOnZoomExtents = value;
+
+                    foreach (var axis in YAxes)
+                        if (axis is AxisBaseViewModel vm)
+                            vm.RangeSyncSourceOnZoomExtents = value;
+                }
+            }
+        }
+    }
+}

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainViewModel.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainViewModel.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Windows.Media;
+using SciChart.Charting.Common.Extensions;
+using SciChart.Charting.Model.ChartSeries;
+using SciChart.Charting.Model.DataSeries;
+using SciChart.Charting.Visuals.Axes;
+using SciChart.Data.Model;
+
+namespace SciChart.Mvvm.Tutorial
+{
+    public class MainViewModel : BindableObject
+    {
+        public ChartViewModel CelsiusChart { get; }
+        public ChartViewModel FahrenheitChart { get; }
+
+        public MainViewModel()
+        {
+            CelsiusChart = BuildCelsiusChart();
+            FahrenheitChart = BuildFahrenheitChart();
+
+            CelsiusChart.RenderableSeries.ZoomExtentsWhenReady();
+            FahrenheitChart.RenderableSeries.ZoomExtentsWhenReady();
+        }
+
+        private ChartViewModel BuildCelsiusChart()
+        {
+            var chart = new ChartViewModel { ChartTitle = "Temperature (°C)" };
+
+            // X axis — synced with the Fahrenheit chart's X axis.
+            // Both share "TimeGroup" with no transform (same time unit).
+            chart.XAxes.Add(new NumericAxisViewModel
+            {
+                AxisTitle = "Time (s)",
+                AutoRange = AutoRange.Once,
+                RangeSyncGroupId = "TimeGroup"
+            });
+
+            // Y axis — synced with the Fahrenheit chart's Y axis.
+            // No transform: this axis's range IS the canonical group range (Celsius).
+            //
+            // RangeSyncOnZoomExtents = true makes this axis the authoritative source
+            // for the "TempGroup" during ZoomExtents. When ZoomExtents fires on either
+            // chart, this axis computes its own extents and pushes them to the group;
+            // the Fahrenheit axis then converts via FromGroupRange.
+            chart.YAxes.Add(new NumericAxisViewModel
+            {
+                AxisTitle = "°C",
+                AutoRange = AutoRange.Once,
+                RangeSyncGroupId = "TempGroup"
+            });
+
+            // Enable RangeSyncOnZoomExtents on all axes in this chart.
+            // This makes ZoomExtents propagate the computed extents to the sync group.
+            chart.RangeSyncOnZoomExtents = true;
+
+            // Sample data: a temperature signal oscillating around 20 °C
+            var ds = new XyDataSeries<double, double> { SeriesName = "Sensor (°C)" };
+            for (int i = 0; i < 500; i++)
+            {
+                double x = i * 0.1;
+                ds.Append(x, 20 + 10 * Math.Sin(x * 0.5) + 5 * Math.Sin(x * 1.3));
+            }
+
+            chart.RenderableSeries.Add(new LineRenderableSeriesViewModel
+            {
+                DataSeries = ds,
+                Stroke = Color.FromRgb(0x50, 0xC7, 0xE0),
+                StrokeThickness = 2
+            });
+
+            return chart;
+        }
+
+        private ChartViewModel BuildFahrenheitChart()
+        {
+            var chart = new ChartViewModel { ChartTitle = "Temperature (°F)" };
+
+            // X axis — same sync group, no transform
+            chart.XAxes.Add(new NumericAxisViewModel
+            {
+                AxisTitle = "Time (s)",
+                AutoRange = AutoRange.Once,
+                RangeSyncGroupId = "TimeGroup"
+            });
+
+            // Y axis — same sync group as the Celsius chart, but with a transform.
+            // This axis displays Fahrenheit; the group range is Celsius.
+            // CelsiusFahrenheitTransform converts between the two:
+            //   ToGroupRange:   F → C  (when this axis changes, broadcast Celsius to the group)
+            //   FromGroupRange: C → F  (when the group changes, update this axis to Fahrenheit)
+            chart.YAxes.Add(new NumericAxisViewModel
+            {
+                AxisTitle = "°F",
+                AutoRange = AutoRange.Once,
+                RangeSyncGroupId = "TempGroup",
+                RangeSyncTransform = new CelsiusFahrenheitTransform()
+            });
+
+            // Same signal converted to Fahrenheit: F = C × 9/5 + 32
+            var ds = new XyDataSeries<double, double> { SeriesName = "Sensor (°F)" };
+            for (int i = 0; i < 500; i++)
+            {
+                double x = i * 0.1;
+                double celsius = 20 + 10 * Math.Sin(x * 0.5) + 5 * Math.Sin(x * 1.3);
+                ds.Append(x, celsius * 9.0 / 5.0 + 32);
+            }
+
+            chart.RenderableSeries.Add(new LineRenderableSeriesViewModel
+            {
+                DataSeries = ds,
+                Stroke = Color.FromRgb(0xF4, 0x84, 0x20),
+                StrokeThickness = 2
+            });
+
+            return chart;
+        }
+    }
+}

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainWindow.xaml
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainWindow.xaml
@@ -1,0 +1,67 @@
+<Window x:Class="SciChart.Mvvm.Tutorial.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SciChart.Mvvm.Tutorial"
+        xmlns:s="http://schemas.abtsoftware.co.uk/scichart"
+        mc:Ignorable="d"
+        Title="Tutorial 10b — Synchronizing Axis Ranges with MVVM"
+        Height="650"
+        Width="800">
+
+    <Window.Resources>
+        <local:MainViewModel x:Key="MainViewModel"/>
+    </Window.Resources>
+
+    <Grid DataContext="{StaticResource MainViewModel}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Chart 1: Temperature in Celsius -->
+        <Grid Grid.Row="0">
+            <s:SciChartSurface ChartTitle="{Binding CelsiusChart.ChartTitle}"
+                               RenderableSeries="{s:SeriesBinding CelsiusChart.RenderableSeries}"
+                               XAxes="{s:AxesBinding CelsiusChart.XAxes}"
+                               YAxes="{s:AxesBinding CelsiusChart.YAxes}">
+                <s:SciChartSurface.ChartModifier>
+                    <s:ModifierGroup>
+                        <s:RubberBandXyZoomModifier/>
+                        <s:ZoomPanModifier ExecuteOn="MouseRightButton"/>
+                        <s:ZoomExtentsModifier/>
+                        <s:MouseWheelZoomModifier/>
+                        <s:XAxisDragModifier />
+                        <s:YAxisDragModifier />
+                    </s:ModifierGroup>
+                </s:SciChartSurface.ChartModifier>
+            </s:SciChartSurface>
+
+            <CheckBox Margin="8" VerticalAlignment="Top" HorizontalAlignment="Left" Foreground="#FFF" Content="RangeSyncSourceOnZoomExtents"
+                      IsChecked="{Binding CelsiusChart.RangeSyncOnZoomExtents, Mode=TwoWay}"/>
+        </Grid>
+
+        <!-- Chart 2: Temperature in Fahrenheit -->
+        <Grid Grid.Row="1">
+            <s:SciChartSurface ChartTitle="{Binding FahrenheitChart.ChartTitle}"
+                               RenderableSeries="{s:SeriesBinding FahrenheitChart.RenderableSeries}"
+                               XAxes="{s:AxesBinding FahrenheitChart.XAxes}"
+                               YAxes="{s:AxesBinding FahrenheitChart.YAxes}">
+                <s:SciChartSurface.ChartModifier>
+                    <s:ModifierGroup>
+                        <s:RubberBandXyZoomModifier/>
+                        <s:ZoomPanModifier ExecuteOn="MouseRightButton"/>
+                        <s:ZoomExtentsModifier/>
+                        <s:MouseWheelZoomModifier/>
+                        <s:XAxisDragModifier />
+                        <s:YAxisDragModifier />
+                    </s:ModifierGroup>
+                </s:SciChartSurface.ChartModifier>
+            </s:SciChartSurface>
+
+            <CheckBox Margin="8" VerticalAlignment="Top" HorizontalAlignment="Left" Foreground="#FFF" Content="RangeSyncSourceOnZoomExtents"
+                      IsChecked="{Binding FahrenheitChart.RangeSyncOnZoomExtents, Mode=TwoWay}"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainWindow.xaml.cs
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace SciChart.Mvvm.Tutorial
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/NuGet.config
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear/>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json"/>
+  </packageSources>
+</configuration>

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+	<PropertyGroup>
+		<Company>SciChart Ltd</Company>
+		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
+		<TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+		<UseWPF>True</UseWPF>
+		<OutputType>WinExe</OutputType>
+		<OutputPath>bin\$(Configuration)</OutputPath>
+		<RootNamespace>SciChart.Mvvm.Tutorial</RootNamespace>
+		<AssemblyName>SciChart.Mvvm.Tutorial</AssemblyName>
+		<LangVersion>Latest</LangVersion>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+		<Reference Include="System" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Runtime.Serialization" />
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="System.Xml" />
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Xml.Linq" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Net.Http" />
+		<Reference Include="System.Xaml">
+			<RequiredTargetFramework>4.0</RequiredTargetFramework>
+		</Reference>
+		<Reference Include="WindowsBase" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="SciChart" Version="*-*" />
+	</ItemGroup>
+</Project>

--- a/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM.sln
+++ b/Tutorials/MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM/Tutorial 10b Synchronizing Axis Ranges with MVVM.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tutorial 10b Synchronizing Axis Ranges with MVVM", "Tutorial 10b Synchronizing Axis Ranges with MVVM.csproj", "{8E4A2F1B-C3D5-4F67-A8B9-0E1D2C3F4A5B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E4A2F1B-C3D5-4F67-A8B9-0E1D2C3F4A5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E4A2F1B-C3D5-4F67-A8B9-0E1D2C3F4A5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E4A2F1B-C3D5-4F67-A8B9-0E1D2C3F4A5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E4A2F1B-C3D5-4F67-A8B9-0E1D2C3F4A5B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5A6B7C8D-9E0F-1A2B-3C4D-5E6F7A8B9C0D}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- Adds Tutorial 10b: Synchronizing Axis Ranges with MVVM to `Tutorials/MVVM/`
- Demonstrates axis range synchronization across multiple charts with a `CelsiusFahrenheitTransform` (converted Y-axis sync group)
- Includes `NuGet.config`, `.sln`, `.csproj` targeting `net462;net6.0-windows`, matching the existing tutorial structure

## YouTrack
[SC-9370](https://abtsoftware.myjetbrains.com/youtrack/issue/SC-9370/Upload-Tutorial-10-to-the-Sanbox)

## Test plan
- [ ] Build with `BuildExamples.ps1` — solution should be picked up and build cleanly for both `net462` and `net6.0-windows`
- [ ] Open standalone `.sln` in Visual Studio and verify the app runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)