### PR TITLE
SC-9379: Update SciChart NuGet package references to 8.*-*

### DIFF
--- a/Examples/SciChart.Examples.Demo/SciChart.Examples.Demo.csproj
+++ b/Examples/SciChart.Examples.Demo/SciChart.Examples.Demo.csproj
@@ -101,15 +101,15 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="8.11.*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart3D" Version="8.11.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DirectX" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DirectX" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DrawingTools" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DrawingTools" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Examples/SciChart.Examples.ExternalDependencies/SciChart.Examples.ExternalDependencies.csproj
+++ b/Examples/SciChart.Examples.ExternalDependencies/SciChart.Examples.ExternalDependencies.csproj
@@ -33,15 +33,15 @@
     <Resource Include="Resources\Objects\*.jpg" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="8.11.*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart3D" Version="8.11.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DirectX" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DirectX" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DrawingTools" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DrawingTools" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Examples/SciChart.Examples/SciChart.Examples.csproj
+++ b/Examples/SciChart.Examples/SciChart.Examples.csproj
@@ -46,15 +46,15 @@
     <Resource Include="Resources\Images\*.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="8.11.*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart3D" Version="8.11.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DirectX" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DirectX" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart.DrawingTools" Version="8.11.*-*" />
+    <PackageReference Include="SciChart.DrawingTools" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/3DChartChangePropertiesDynamically/3DChartChangePropertiesDynamically.csproj
+++ b/Sandbox/CustomerExamples/3DChartChangePropertiesDynamically/3DChartChangePropertiesDynamically.csproj
@@ -30,7 +30,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/3DChartScatterSeriesOnWalls/Scatter3DOnChartWalls.csproj
+++ b/Sandbox/CustomerExamples/3DChartScatterSeriesOnWalls/Scatter3DOnChartWalls.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/3DChartSelectPointsOnSurfaceMesh/SurfaceMesh3DWithSelectablePoints.csproj
+++ b/Sandbox/CustomerExamples/3DChartSelectPointsOnSurfaceMesh/SurfaceMesh3DWithSelectablePoints.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/3DScatterChart_DragPointModifier/Scatter3DChart_DragPointModifier.csproj
+++ b/Sandbox/CustomerExamples/3DScatterChart_DragPointModifier/Scatter3DChart_DragPointModifier.csproj
@@ -30,7 +30,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AddObjectsToA3DChart/AddObjectsToA3DChart/AddObjectsToA3DChart.csproj
+++ b/Sandbox/CustomerExamples/AddObjectsToA3DChart/AddObjectsToA3DChart/AddObjectsToA3DChart.csproj
@@ -15,7 +15,7 @@
 		<Resource Include="WhiteWoodTexture.jpg" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AnimatedDataSeries/AnimatedDataSeriesFilter.csproj
+++ b/Sandbox/CustomerExamples/AnimatedDataSeries/AnimatedDataSeriesFilter.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AnnotationDragModifier3D/AnnotationDragModifier3D.csproj
+++ b/Sandbox/CustomerExamples/AnnotationDragModifier3D/AnnotationDragModifier3D.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AnnotationsBindingToTextBox/AnnotationsBindingToTextBox.csproj
+++ b/Sandbox/CustomerExamples/AnnotationsBindingToTextBox/AnnotationsBindingToTextBox.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AspectRatioGridLines/AspectRatioGridLines.csproj
+++ b/Sandbox/CustomerExamples/AspectRatioGridLines/AspectRatioGridLines.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AspectRatioSandbox/AspectRatios.csproj
+++ b/Sandbox/CustomerExamples/AspectRatioSandbox/AspectRatios.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/AxisMvvmApplyStyle/AxisMvvmApplyStyle/AxisMvvmApplyStyle.csproj
+++ b/Sandbox/CustomerExamples/AxisMvvmApplyStyle/AxisMvvmApplyStyle/AxisMvvmApplyStyle.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ChartPrinting/ChartPrintingMultiPaneCharts.csproj
+++ b/Sandbox/CustomerExamples/ChartPrinting/ChartPrintingMultiPaneCharts.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ColumnSeriesNoGaps/ColumnSeriesNoGaps.csproj
+++ b/Sandbox/CustomerExamples/ColumnSeriesNoGaps/ColumnSeriesNoGaps.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CompositeAnnotationsMvvm/CompositeAnnotationsMvvm.csproj
+++ b/Sandbox/CustomerExamples/CompositeAnnotationsMvvm/CompositeAnnotationsMvvm.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomAxisBandsProvider/CustomAxisBandsProvider.csproj
+++ b/Sandbox/CustomerExamples/CustomAxisBandsProvider/CustomAxisBandsProvider.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomCompositeAnnotationExample/CustomCompositeAnnotationExample.csproj
+++ b/Sandbox/CustomerExamples/CustomCompositeAnnotationExample/CustomCompositeAnnotationExample.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomModifiersSandbox/CustomModifierSandbox.csproj
+++ b/Sandbox/CustomerExamples/CustomModifiersSandbox/CustomModifierSandbox.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomPointMarker/CustomPointMarker.csproj
+++ b/Sandbox/CustomerExamples/CustomPointMarker/CustomPointMarker.csproj
@@ -29,6 +29,6 @@
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="2.9.0" />
-    <PackageReference Include="SciChart" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomSeriesMvvm/CustomSeriesMvvm.csproj
+++ b/Sandbox/CustomerExamples/CustomSeriesMvvm/CustomSeriesMvvm.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
+++ b/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
@@ -29,6 +29,6 @@
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="2.9.0" />
-    <PackageReference Include="SciChart" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/DPI_Aware_SciChartSurface/DpiAware_SciChartSurface.csproj
+++ b/Sandbox/CustomerExamples/DPI_Aware_SciChartSurface/DpiAware_SciChartSurface.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="MahApps.Metro.IconPacks.Material" Version="4.11.0" />
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart.DrawingTools" Version="*-*" />
-    <PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart.DrawingTools" Version="8.*-*" />
+    <PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />

--- a/Sandbox/CustomerExamples/DashedLinesChart/DashedLinesChart.csproj
+++ b/Sandbox/CustomerExamples/DashedLinesChart/DashedLinesChart.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/DigitalAnalyzerPerformanceDemo/SciChart_DigitalAnalyzerPerformanceDemo.csproj
+++ b/Sandbox/CustomerExamples/DigitalAnalyzerPerformanceDemo/SciChart_DigitalAnalyzerPerformanceDemo.csproj
@@ -30,9 +30,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39"/>
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="4.11.0"/>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
-		<PackageReference Include="SciChart.DrawingTools" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
+		<PackageReference Include="SciChart.DrawingTools" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/DoubleAxisAsDateTimeAxis/DoubleAxisAsDateTimeAxis.csproj
+++ b/Sandbox/CustomerExamples/DoubleAxisAsDateTimeAxis/DoubleAxisAsDateTimeAxis.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart3D" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/DoubleScaleDiscontinuousDateTimeAxis/DoubleScaleDiscontinuousDateTimeAxis.csproj
+++ b/Sandbox/CustomerExamples/DoubleScaleDiscontinuousDateTimeAxis/DoubleScaleDiscontinuousDateTimeAxis.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/DynamicVerticallyStackedAxis/DynamicVerticallyStackedAxis.csproj
+++ b/Sandbox/CustomerExamples/DynamicVerticallyStackedAxis/DynamicVerticallyStackedAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/EliminatingFlickerInDirectXRenderer/EliminatingFlicker.csproj
+++ b/Sandbox/CustomerExamples/EliminatingFlickerInDirectXRenderer/EliminatingFlicker.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/EventOnZoomExtentsCompleted/EventOnZoomExtentsCompleted.csproj
+++ b/Sandbox/CustomerExamples/EventOnZoomExtentsCompleted/EventOnZoomExtentsCompleted.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/HitTestSandbox/HitTestSandbox.csproj
+++ b/Sandbox/CustomerExamples/HitTestSandbox/HitTestSandbox.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart3D" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ImplicitStyles/ImplicitStyles.csproj
+++ b/Sandbox/CustomerExamples/ImplicitStyles/ImplicitStyles.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/KeyboardMoveXozModifier3D/KeyboardMoveXozModifier3D.csproj
+++ b/Sandbox/CustomerExamples/KeyboardMoveXozModifier3D/KeyboardMoveXozModifier3D.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/LabStyleCharts/LabStyleCharts.csproj
+++ b/Sandbox/CustomerExamples/LabStyleCharts/LabStyleCharts.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/LabelIndividualStylingColoring/LabelIndividualStylingColoring.csproj
+++ b/Sandbox/CustomerExamples/LabelIndividualStylingColoring/LabelIndividualStylingColoring.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/LegendAxisVisibilityCheckbox/LegendAxisVisibilityCheckbox.csproj
+++ b/Sandbox/CustomerExamples/LegendAxisVisibilityCheckbox/LegendAxisVisibilityCheckbox.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/Lidar3DPointCloudDemo/Lidar3DPointCloudDemo.csproj
+++ b/Sandbox/CustomerExamples/Lidar3DPointCloudDemo/Lidar3DPointCloudDemo.csproj
@@ -28,8 +28,8 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart3D" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
   <ItemGroup>
     <None Update="LIDAR-DSM-2M-TQ38sw\tq3080_DSM_2M.asc">

--- a/Sandbox/CustomerExamples/MarketProfileTradingExample/MarketProfileTradingChart.csproj
+++ b/Sandbox/CustomerExamples/MarketProfileTradingExample/MarketProfileTradingChart.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/MirroredYAxis/MvvmVersion/mirrored YAxis/mirrored YAxis.csproj
+++ b/Sandbox/CustomerExamples/MirroredYAxis/MvvmVersion/mirrored YAxis/mirrored YAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/MirroredYAxis/XamlVersion/mirrored YAxis/mirrored YAxis.csproj
+++ b/Sandbox/CustomerExamples/MirroredYAxis/XamlVersion/mirrored YAxis/mirrored YAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/MouseEventsOnAnnotations/MouseEventsOnAnnotations.csproj
+++ b/Sandbox/CustomerExamples/MouseEventsOnAnnotations/MouseEventsOnAnnotations.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/MultiLineDateTimeAxisLabels/MultiLineDateTimeAxisLabels.csproj
+++ b/Sandbox/CustomerExamples/MultiLineDateTimeAxisLabels/MultiLineDateTimeAxisLabels.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/MutipleAppDomainsExample/MutipleAppDomainsExample.csproj
+++ b/Sandbox/CustomerExamples/MutipleAppDomainsExample/MutipleAppDomainsExample.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 	
 </Project>

--- a/Sandbox/CustomerExamples/MutipleUIThreadExample/MutipleUIThreadExample.csproj
+++ b/Sandbox/CustomerExamples/MutipleUIThreadExample/MutipleUIThreadExample.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/OffScreenExportExample/OffScreenExportExample.csproj
+++ b/Sandbox/CustomerExamples/OffScreenExportExample/OffScreenExportExample.csproj
@@ -29,6 +29,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/OilAndGasExample/OilAndGasExample.csproj
+++ b/Sandbox/CustomerExamples/OilAndGasExample/OilAndGasExample.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart3D" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/Plane3DAnnotation/Plane3DAnnotation.csproj
+++ b/Sandbox/CustomerExamples/Plane3DAnnotation/Plane3DAnnotation.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart3D" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart3D" Version="8.*-*" />
   </ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ResamplingOfGridDataSeries3D/ResamplingOfGridDataSeries3D.csproj
+++ b/Sandbox/CustomerExamples/ResamplingOfGridDataSeries3D/ResamplingOfGridDataSeries3D.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/RotatedAxisLabels/RotatedAxisLabels.csproj
+++ b/Sandbox/CustomerExamples/RotatedAxisLabels/RotatedAxisLabels.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/SciChartSurfaceMeshSelection/SciChartSurfaceMeshSelection.csproj
+++ b/Sandbox/CustomerExamples/SciChartSurfaceMeshSelection/SciChartSurfaceMeshSelection.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/SciChart_SyncMultiChartMvvm/SciChart_SyncMultiChartMvvm.csproj
+++ b/Sandbox/CustomerExamples/SciChart_SyncMultiChartMvvm/SciChart_SyncMultiChartMvvm.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ScrollbarAboveAxis/ScrollbarAboveAxis.csproj
+++ b/Sandbox/CustomerExamples/ScrollbarAboveAxis/ScrollbarAboveAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ScrollbarMvvmAxis/ScrollbarMvvmAxis.csproj
+++ b/Sandbox/CustomerExamples/ScrollbarMvvmAxis/ScrollbarMvvmAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/SelectSeriesOnHover/SelectSeriesOnHover/SelectSeriesOnHover.csproj
+++ b/Sandbox/CustomerExamples/SelectSeriesOnHover/SelectSeriesOnHover/SelectSeriesOnHover.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/SlimLineRenderableSeries/SlimLineRenderableSeriesExample.csproj
+++ b/Sandbox/CustomerExamples/SlimLineRenderableSeries/SlimLineRenderableSeriesExample.csproj
@@ -30,7 +30,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/State Series Example/Method1 Chartception/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method1 Chartception/State Series Example.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/State Series Example/Method2 Axis Panel Template/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method2 Axis Panel Template/State Series Example.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/State Series Example/Method3 Custom Series/State Series Example.csproj
+++ b/Sandbox/CustomerExamples/State Series Example/Method3 Custom Series/State Series Example.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/StockChartLogAxis/StockChartLogAxis.csproj
+++ b/Sandbox/CustomerExamples/StockChartLogAxis/StockChartLogAxis.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/StringsOnXAxis/StringsOnXAxis.csproj
+++ b/Sandbox/CustomerExamples/StringsOnXAxis/StringsOnXAxis.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/StripChart/ScrollingStripChart.csproj
+++ b/Sandbox/CustomerExamples/StripChart/ScrollingStripChart.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers.csproj
+++ b/Sandbox/CustomerExamples/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers/StrokeDashArrayPointMarkers.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/SweepingEcgSeries/SweepingEcg.csproj
+++ b/Sandbox/CustomerExamples/SweepingEcgSeries/SweepingEcg.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/Sandbox/CustomerExamples/TextAnnotationDynamicSize/TextAnnotationDynamicSize.csproj
+++ b/Sandbox/CustomerExamples/TextAnnotationDynamicSize/TextAnnotationDynamicSize.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ThresholdedLineSeries/DragThresholdMvvm.csproj
+++ b/Sandbox/CustomerExamples/ThresholdedLineSeries/DragThresholdMvvm.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.ExternalDependencies" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.ExternalDependencies" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/TicklinesUniformGrid/TicklinesUniformGrid.csproj
+++ b/Sandbox/CustomerExamples/TicklinesUniformGrid/TicklinesUniformGrid.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/TimelineControl/TimeLineControl.csproj
+++ b/Sandbox/CustomerExamples/TimelineControl/TimeLineControl.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/TouchScreenModifiers/TouchInputSandbox.csproj
+++ b/Sandbox/CustomerExamples/TouchScreenModifiers/TouchInputSandbox.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/TruePolar/TruePolarChart.csproj
+++ b/Sandbox/CustomerExamples/TruePolar/TruePolarChart.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/UsingRenderContextAPI/UsingRenderContextApi.csproj
+++ b/Sandbox/CustomerExamples/UsingRenderContextAPI/UsingRenderContextApi.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 	<ItemGroup>
 	  <None Update="Resources\TestImage.jpg">

--- a/Sandbox/CustomerExamples/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate.csproj
+++ b/Sandbox/CustomerExamples/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate/VS2022_Net60_Boilerplate.csproj
@@ -9,6 +9,6 @@
 		<LangVersion>Latest</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/VerticalSliceModifierMvvm/VerticalSliceModifierMvvm.csproj
+++ b/Sandbox/CustomerExamples/VerticalSliceModifierMvvm/VerticalSliceModifierMvvm.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/VisualXcceleratorEnableTest/VisualXcceleratorEnableTest.csproj
+++ b/Sandbox/CustomerExamples/VisualXcceleratorEnableTest/VisualXcceleratorEnableTest.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/YAxisSameZeroLine/YAxisSameZeroLine.csproj
+++ b/Sandbox/CustomerExamples/YAxisSameZeroLine/YAxisSameZeroLine.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Core" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Interfaces" Version="5.0.0" />

--- a/Sandbox/CustomerExamples/ZoomExtentsAfterMvvmSeriesChanges/ZoomExtentsAfterMvvmSeriesChanged.csproj
+++ b/Sandbox/CustomerExamples/ZoomExtentsAfterMvvmSeriesChanges/ZoomExtentsAfterMvvmSeriesChanged.csproj
@@ -28,6 +28,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Sandbox/CustomerExamples/ZoomExtentsOnVisibilityChanged/ZoomExtentsOnVisibilityChanged.csproj
+++ b/Sandbox/CustomerExamples/ZoomExtentsOnVisibilityChanged/ZoomExtentsOnVisibilityChanged.csproj
@@ -28,7 +28,7 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0" />
   </ItemGroup>

--- a/Sandbox/DirectXDeploymentTestApp/NuGet PackageReference version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
+++ b/Sandbox/DirectXDeploymentTestApp/NuGet PackageReference version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*"/>
-		<PackageReference Include="SciChart.DirectX" Version="*-*"/>
+		<PackageReference Include="SciChart" Version="8.*-*"/>
+		<PackageReference Include="SciChart.DirectX" Version="8.*-*"/>
 	</ItemGroup>
 
 </Project>

--- a/Sandbox/DirectXDeploymentTestApp/NuGet Packages.config version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
+++ b/Sandbox/DirectXDeploymentTestApp/NuGet Packages.config version/DirectXDeploymentTestApp/DirectXDeploymentTestApp.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SciChart" Version="*-*" />
-    <PackageReference Include="SciChart.DirectX" Version="*-*" />
+    <PackageReference Include="SciChart" Version="8.*-*" />
+    <PackageReference Include="SciChart.DirectX" Version="8.*-*" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />

--- a/Sandbox/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo.csproj
+++ b/Sandbox/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo/Fifo100MillionPointsDemo.csproj
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 		<PackageReference Include="SciChart.Wpf.UI" Version="3.1.251" />
 		<PackageReference Include="SciChart.Wpf.UI.Transitionz" Version="3.1.251" />
 	</ItemGroup>

--- a/Sandbox/LicensingTestApp/WinForms/WindowsFormsApplication1/WindowsFormsApplication1/WindowsFormsApplication1.csproj
+++ b/Sandbox/LicensingTestApp/WinForms/WindowsFormsApplication1/WindowsFormsApplication1/WindowsFormsApplication1.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 
 </Project>

--- a/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App net6.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App net6.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 
 </Project>

--- a/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - .NET 6.0/WpfApplication1/Licensing Test App.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 
 </Project>

--- a/Sandbox/LicensingTestApp/Wpf - AsyncLicenseLoading/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf - AsyncLicenseLoading/WpfApplication1/Licensing Test App.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 		<PackageReference Include="SciChart.Wpf.UI.Transitionz" Version="3.1.251" />
 	</ItemGroup>
 

--- a/Sandbox/LicensingTestApp/Wpf/WpfApplication1/Licensing Test App.csproj
+++ b/Sandbox/LicensingTestApp/Wpf/WpfApplication1/Licensing Test App.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 
 </Project>

--- a/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart_Trunk/ChartProviderSciChart_Trunk.csproj
+++ b/Sandbox/WPFChartPerformanceBenchmark/ChartProviderSciChart_Trunk/ChartProviderSciChart_Trunk.csproj
@@ -33,8 +33,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
-		<PackageReference Include="SciChart.DirectX" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
+		<PackageReference Include="SciChart.DirectX" Version="8.*-*" />
 		<PackageReference Include="SharpDX" Version="4.2.0" />
 		<PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
 		<PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />

--- a/Tutorials/Code-Behind/Tutorial 02 Creating a SciChartSurface/Tutorial 02 Creating a SciChartSurface.csproj
+++ b/Tutorials/Code-Behind/Tutorial 02 Creating a SciChartSurface/Tutorial 02 Creating a SciChartSurface.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 03 Adding Series to a Chart/Tutorial 03 Adding Series to a Chart.csproj
+++ b/Tutorials/Code-Behind/Tutorial 03 Adding Series to a Chart/Tutorial 03 Adding Series to a Chart.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 04 Adding Zooming, Panning/Tutorial 04 Adding Zooming, Panning.csproj
+++ b/Tutorials/Code-Behind/Tutorial 04 Adding Zooming, Panning/Tutorial 04 Adding Zooming, Panning.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 05 Adding Tooltips, Legends/Tutorial 05 Adding Tooltips, Legends.csproj
+++ b/Tutorials/Code-Behind/Tutorial 05 Adding Tooltips, Legends/Tutorial 05 Adding Tooltips, Legends.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 06 Realtime Updates/Tutorial 06 Realtime Updates.csproj
+++ b/Tutorials/Code-Behind/Tutorial 06 Realtime Updates/Tutorial 06 Realtime Updates.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 07 Adding Annotations/Tutorial 07 Adding Annotations.csproj
+++ b/Tutorials/Code-Behind/Tutorial 07 Adding Annotations/Tutorial 07 Adding Annotations.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 08 Multiple Axis/Tutorial 08 Multiple Axis.csproj
+++ b/Tutorials/Code-Behind/Tutorial 08 Multiple Axis/Tutorial 08 Multiple Axis.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/Code-Behind/Tutorial 09 Linking Multiple Charts/Tutorial 09 Linking Multiple Charts.csproj
+++ b/Tutorials/Code-Behind/Tutorial 09 Linking Multiple Charts/Tutorial 09 Linking Multiple Charts.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 02b Creating a SciChartSurface with MVVM/Tutorial 02b Creating a SciChartSurface with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 02b Creating a SciChartSurface with MVVM/Tutorial 02b Creating a SciChartSurface with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 03b Adding Series to a Chart with MVVM/Tutorial 03b Adding Series to a Chart with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 03b Adding Series to a Chart with MVVM/Tutorial 03b Adding Series to a Chart with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 04b Adding Zooming Panning with MVVM/Tutorial 04b Adding Zooming Panning with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 04b Adding Zooming Panning with MVVM/Tutorial 04b Adding Zooming Panning with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM/Tutorial 05b Adding Tooltips, Legends with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 06b Adding Realtime Updates with MVVM/Tutorial 06b Adding Realtime Updates with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 06b Adding Realtime Updates with MVVM/Tutorial 06b Adding Realtime Updates with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 07b Adding Annotations with MVVM/Tutorial 07b Adding Annotations with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 07b Adding Annotations with MVVM/Tutorial 07b Adding Annotations with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 08b Adding Multiple Axis with MVVM/Tutorial 08b Adding Multiple Axis with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 08b Adding Multiple Axis with MVVM/Tutorial 08b Adding Multiple Axis with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/MVVM/Tutorial 09b Linking Multiple Charts with MVVM/Tutorial 09b Linking Multiple Charts with MVVM.csproj
+++ b/Tutorials/MVVM/Tutorial 09b Linking Multiple Charts with MVVM/Tutorial 09b Linking Multiple Charts with MVVM.csproj
@@ -30,6 +30,6 @@
 		<Reference Include="PresentationFramework" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart" Version="*-*" />
+		<PackageReference Include="SciChart" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/SciChart 3D/Tutorial 02-3D Creating a SciChart3DSurface/Tutorial 02 Creating a SciChart3DSurface.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 02-3D Creating a SciChart3DSurface/Tutorial 02 Creating a SciChart3DSurface.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 	
 </Project>

--- a/Tutorials/SciChart 3D/Tutorial 03-3D Adding Series to a 3D Chart/Tutorial 03 Adding Series to a 3D Chart.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 03-3D Adding Series to a 3D Chart/Tutorial 03 Adding Series to a 3D Chart.csproj
@@ -10,6 +10,6 @@
 		<LangVersion>Latest</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="SciChart3D" Version="*-*" />
+		<PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>

--- a/Tutorials/SciChart 3D/Tutorial 04-3D Adding Zooming, Panning Behavior/Tutorial 04 Adding Zooming Panning Behavior.csproj
+++ b/Tutorials/SciChart 3D/Tutorial 04-3D Adding Zooming, Panning Behavior/Tutorial 04 Adding Zooming Panning Behavior.csproj
@@ -11,6 +11,6 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="SciChart3D" Version="*-*" />
+	  <PackageReference Include="SciChart3D" Version="8.*-*" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Updated all SciChart NuGet `PackageReference` versions to `8.*-*` across Examples, Sandbox, and Tutorials
- `*-*` (bare wildcard) → `8.*-*` in Sandbox and Tutorials (101 files)
- `8.11.*-*` → `8.*-*` in Examples (3 files)

Resolves SC-9379

## Test plan
- [ ] Verify NuGet restore picks up SciChart v8.x packages
- [ ] Build representative projects from each folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)