### PR TITLE
SC-9394 Fix invalid UTF-8 encoding in CustomShapeZoomModifier.csproj

### DIFF
--- a/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
+++ b/Sandbox/CustomerExamples/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier/CustomShapeZoomModifier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 	<PropertyGroup>
 		<Company>SciChart Ltd</Company>
-		<Copyright>Copyright © SciChart Ltd 2011-2026</Copyright>
+		<Copyright>Copyright Â© SciChart Ltd 2011-2026</Copyright>
 		<TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
 		<UseWPF>True</UseWPF>
 		<OutputType>WinExe</OutputType>


### PR DESCRIPTION
## Summary
- Fix invalid Latin-1 encoding of `©` copyright symbol in `CustomShapeZoomModifier.csproj` that caused XML parsing build error

## Related
- YouTrack: [SC-9394](https://abtsoftware.myjetbrains.com/youtrack/issue/SC-9394)
- Parent: [SC-9392](https://abtsoftware.myjetbrains.com/youtrack/issue/SC-9392)

🤖 Generated with [Claude Code](https://claude.com/claude-code)